### PR TITLE
[WL-23] Add Tabs variants

### DIFF
--- a/src/components/ui/tabs/index.tsx
+++ b/src/components/ui/tabs/index.tsx
@@ -1,28 +1,73 @@
 "use client";
 
 import * as TabsPrimitive from "@radix-ui/react-tabs";
+import { cva } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/utils/shadcn";
 
-function Tabs({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Root>) {
-  return <TabsPrimitive.Root data-slot="tabs" className={cn("flex flex-col gap-2", className)} {...props} />;
-}
+type Variant = "default" | "underline" | "filled";
 
-function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+const TabVariantContext = React.createContext<Variant>("default");
+
+export const useTabVariantContext = () => {
+  const context = React.useContext(TabVariantContext);
+  if (context === undefined) {
+    throw new Error("useTabVariantContext must be used within a Tabs component");
+  }
+  return context;
+};
+
+type TabsProps = React.ComponentProps<typeof TabsPrimitive.Root> & { variant: Variant };
+
+function Tabs({ className, variant = "default", ...props }: TabsProps) {
   return (
-    <TabsPrimitive.List data-slot="tabs-list" className={cn("bg-muted flex rounded-md p-1", className)} {...props} />
+    <TabVariantContext.Provider value={variant}>
+      <TabsPrimitive.Root data-slot="tabs" className={cn("flex flex-col gap-2", className)} {...props} />
+    </TabVariantContext.Provider>
   );
 }
 
+const tabsListVariants = cva("flex items-center", {
+  variants: {
+    variant: {
+      default: "bg-muted rounded-md p-1",
+      underline: "bg-background",
+      filled: "bg-background gap-0.5",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
+
+function TabsList({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.List>) {
+  const variant = useTabVariantContext();
+  return <TabsPrimitive.List data-slot="tabs-list" className={tabsListVariants({ className, variant })} {...props} />;
+}
+
+const tabsTriggerVariants = cva(" flex h-8 flex-grow items-center justify-center transition", {
+  variants: {
+    variant: {
+      default:
+        "data-[state=active]:bg-card data-[state=active]:body-medium-plus body-medium text-foreground bg-transparent rounded-sm data-[state=active]:shadow px-4",
+      underline:
+        "bg-background border-b-2 border-transparent hover:border-muted-foreground hover:bg-accent px-3 data-[state=active]:border-primary data-[state=active]:text-primary",
+      filled:
+        "bg-background rounded-sm hover:bg-accent px-4 body-medium data-[state=active]:body-medium-plus data-[state=active]:bg-accent",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+  },
+});
+
 function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPrimitive.Trigger>) {
+  const variant = useTabVariantContext();
   return (
     <TabsPrimitive.Trigger
       data-slot="tabs-trigger"
-      className={cn(
-        "data-[state=active]:bg-card data-[state=active]:body-medium-plus body-medium text-foreground flex h-8 flex-grow items-center justify-center rounded-sm bg-transparent px-4 transition data-[state=active]:shadow",
-        className
-      )}
+      className={tabsTriggerVariants({ className, variant })}
       {...props}
     />
   );

--- a/src/components/ui/tabs/tabs.stories.tsx
+++ b/src/components/ui/tabs/tabs.stories.tsx
@@ -1,0 +1,46 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+const meta = {
+  title: "UI/Tabs",
+  component: Tabs,
+  subcomponents: { TabsList, TabsTrigger },
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    defaultValue: "one",
+    variant: "default",
+  },
+  render: (args) => {
+    return (
+      <Tabs {...args}>
+        <TabsList>
+          <TabsTrigger value="one">Tab One</TabsTrigger>
+          <TabsTrigger value="two">Tab Two</TabsTrigger>
+        </TabsList>
+        <TabsContent value="one">Tab Content One</TabsContent>
+        <TabsContent value="two">Tab Content Two</TabsContent>
+      </Tabs>
+    );
+  },
+} satisfies Meta<typeof Tabs>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Underline: Story = {
+  args: {
+    variant: "underline",
+  },
+};
+
+export const Filled: Story = {
+  args: {
+    variant: "filled",
+  },
+};


### PR DESCRIPTION
Adds two new variants: `underline` and `filled`. `variant` prop is added to the `Tabs` component and defaults to `variant="default"`.