### PR TITLE
[WL-101] Add config option to control dark mode toggle visibility

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -1,4 +1,4 @@
-import { LINKS } from "@/config";
+import { ENABLE_DARK_MODE_TOGGLE, LINKS } from "@/config";
 
 import LinkExternal from "../LinkExternal";
 import { PoweredByMorpho } from "../ui/icons/PoweredByMorpho";
@@ -14,7 +14,7 @@ const FOOTER_ITEMS: { name: string; href: string }[] = [
 export function Footer() {
   return (
     <footer className="text-muted-foreground mb-18 flex w-full items-start justify-between gap-6 py-6 md:items-center lg:mb-0">
-      <div className="flex flex-col gap-6 md:flex-row">
+      <div className="flex min-h-9 flex-col gap-6 md:flex-row">
         <LinkExternal href="https://morpho.org/" keepReferrer className="text-muted-foreground">
           <PoweredByMorpho />
         </LinkExternal>
@@ -25,7 +25,7 @@ export function Footer() {
         ))}
       </div>
 
-      <ThemeToggle />
+      {ENABLE_DARK_MODE_TOGGLE && <ThemeToggle />}
     </footer>
   );
 }

--- a/src/config/index.tsx
+++ b/src/config/index.tsx
@@ -81,3 +81,6 @@ export const KNOWN_ADDRESSES: Record<Address, { name: string; iconSrc?: string }
     iconSrc: "/identity/compound.png",
   },
 };
+
+// Controls the visibility of any dark mode toggles
+export const ENABLE_DARK_MODE_TOGGLE = true;


### PR DESCRIPTION
I added the `min-h-9` to prevent the Footer component from shifting depending on whether or not the button was present.