### PR TITLE
Fix decimals in market name badge

### DIFF
--- a/src/components/market/MarketName/index.tsx
+++ b/src/components/market/MarketName/index.tsx
@@ -60,7 +60,7 @@ export function MarketName({
       <Badge variant={variant === "sm" ? "small" : "default"}>
         <NumberFlow
           value={lltv}
-          format={{ style: "percent", minimumFractionDigits: 0, maximumFractionDigits: 0 }}
+          format={{ style: "percent", minimumFractionDigits: 1, maximumFractionDigits: 2 }}
           className={variant === "sm" ? "body-small-plus" : "body-medium-plus"}
         />
       </Badge>


### PR DESCRIPTION
LLTV for markets can have 1 decimal, which made certain markets like those with 91.5% lltv show rounded in the market name badge.