### PR TITLE
Add dynamic initial range selection to DataChart

### DIFF
--- a/src/app/(app)/borrow/[chainId]/[marketId]/page.tsx
+++ b/src/app/(app)/borrow/[chainId]/[marketId]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 import { Suspense } from "react";
 import { isHex } from "viem";
 import { DataChart } from "@/components/DataChart/DataChart";
+import { parseInitialRange } from "@/components/DataChart/data-domain";
 import { IrmChart } from "@/components/IrmChart";
 import { IrmMetrics, IrmMetricsSkeleton } from "@/components/market/IrmMetrics";
 import MarketActions from "@/components/market/MarketActions";
@@ -182,8 +183,10 @@ async function KeyMetricsWrapper({ chainId, marketId }: MarketIdentifier) {
 async function MarketHistoricalLiquidityChartWrapper({ chainId, marketId }: MarketIdentifier) {
   const market = await getMarket(chainId, marketId);
 
+  const initialRange = parseInitialRange(market.historical);
+
   // Null if the chain doesn't support historical data
-  if (!market || !market.historical || !market.collateralAsset) {
+  if (!market || !market.historical || !market.collateralAsset || !initialRange) {
     return null;
   }
 
@@ -192,6 +195,7 @@ async function MarketHistoricalLiquidityChartWrapper({ chainId, marketId }: Mark
   return (
     <DataChart
       data={market.historical}
+      initialRange={initialRange}
       title="Assets"
       defaultTab="totalBorrowed"
       tabOptions={[
@@ -232,8 +236,10 @@ async function MarketHistoricalLiquidityChartWrapper({ chainId, marketId }: Mark
 async function MarketHistoricalApyChartWrapper({ chainId, marketId }: MarketIdentifier) {
   const market = await getMarket(chainId, marketId);
 
+  const initialRange = parseInitialRange(market.historical);
+
   // Null if the chain doesn't support historical data
-  if (!market || !market.historical || !market.collateralAsset) {
+  if (!market || !market.historical || !market.collateralAsset || !initialRange) {
     return null;
   }
 
@@ -261,6 +267,7 @@ async function MarketHistoricalApyChartWrapper({ chainId, marketId }: MarketIden
   return (
     <DataChart
       data={market.historical}
+      initialRange={initialRange}
       title={`Native Borrow Rate (${APP_CONFIG.apyWindow})`}
       defaultTab={key}
       tabOptions={[

--- a/src/components/DataChart/DataChart.tsx
+++ b/src/components/DataChart/DataChart.tsx
@@ -11,23 +11,22 @@ import { Switch } from "../ui/switch";
 import { ChartHeader } from "./ChartHeader";
 import { CurrencySelector } from "./CurrencySelector";
 import { type DataRange, DateSelector, periods } from "./DateSelector";
-import { getMinX, prepareChartDataWithDomain } from "./data-domain";
+import { getMinX, NO_DATA_POINT_THRESHOLD, prepareChartDataWithDomain } from "./data-domain";
 import { type TabOptions, TabSelector } from "./TabSelector";
 import type { DataEntry, HistoricalData } from "./types";
 import { useIntervalX } from "./useIntervalX";
 
-const NO_DATA_POINT_THRESHOLD = 10; // Need at least this many data points to show a nice chart
-
 interface Props<D extends DataEntry> {
   title: string;
   data: HistoricalData<D>;
+  initialRange: DataRange;
   defaultTab: Exclude<keyof D, "bucketTimestamp">;
   tabOptions?: Array<TabOptions<D>>;
 }
 
 export function DataChart<D extends DataEntry>(props: Props<D>) {
-  const { data: allData, title, defaultTab, tabOptions } = props;
-  const [range, setRange] = useState<DataRange>("1M");
+  const { data: allData, title, defaultTab, tabOptions, initialRange } = props;
+  const [range, setRange] = useState<DataRange>(initialRange);
   const [tab, setTab] = useState<Exclude<keyof D, "bucketTimestamp">>(defaultTab);
   const [withRewards, setWithRewards] = useState(false);
 

--- a/src/components/DataChart/data-domain.ts
+++ b/src/components/DataChart/data-domain.ts
@@ -1,3 +1,4 @@
+import type { Market } from "@/data/whisk/getMarket";
 import type { DataRange } from "./DateSelector";
 import type { DataEntry } from "./types";
 
@@ -5,12 +6,36 @@ const HOUR = 60 * 60;
 const DAY = 24 * HOUR;
 const WEEK = 7 * DAY;
 
+export const NO_DATA_POINT_THRESHOLD = 10; // Need at least this many data points to show a nice chart
+
 const RANGE_DURATION: Record<DataRange, number> = {
   "1W": WEEK,
   "1M": 30 * DAY,
   "6M": 26 * WEEK,
   All: 0,
 } as const;
+
+export function parseInitialRange(data: Market["historical"]): DataRange | undefined {
+  if (!data) return;
+
+  // Determine which ranges are even selectable (mirrors DateSelector)
+  const weekly = data.weekly ?? [];
+  const fullDomain = weekly.length > 1 ? weekly[weekly.length - 1]!.bucketTimestamp - weekly[0]!.bucketTimestamp : 0;
+
+  const selectableRanges: DataRange[] = [];
+  if (fullDomain >= WEEK) selectableRanges.push("1W");
+  if (fullDomain >= WEEK) selectableRanges.push("1M");
+  if (fullDomain >= 30 * DAY) selectableRanges.push("6M");
+  if (fullDomain >= 6 * 30 * DAY) selectableRanges.push("All");
+
+  // Try ranges from smallest to largest and pick the first with enough points
+  for (const range of selectableRanges) {
+    const series = range === "All" ? data.weekly : range === "6M" || range === "1M" ? data.daily : data.hourly;
+
+    const length = estimatePreparedLength(series, range);
+    if (length > NO_DATA_POINT_THRESHOLD) return range;
+  }
+}
 
 export function prepareChartDataWithDomain<D extends DataEntry>(
   data: D[],
@@ -91,4 +116,24 @@ export function getMinX<D extends DataEntry>(data: D[], range: DataRange) {
   const now = Math.floor(Date.now() / 1000);
   const minX = now - RANGE_DURATION[range];
   return minX;
+}
+
+// Estimate the number of points produced by prepareChartDataWithDomain for the given range.
+function estimatePreparedLength<D extends DataEntry>(data: D[] | undefined, range: DataRange): number {
+  if (!data || !data.length || !data[0]) return 0;
+  if (range === "All") return data.length;
+
+  const minX = getMinX(data, range);
+  const maxX = data[data.length - 1]!.bucketTimestamp;
+  if (maxX < minX) return 0;
+
+  const filtered = data.filter((d) => d.bucketTimestamp >= minX);
+  if (!filtered.length) return 0;
+
+  const interval = calculateDataInterval(filtered) || DAY;
+  const delta = Math.max(0, filtered[0]!.bucketTimestamp - minX);
+  const paddingCount = Math.ceil(delta / interval);
+
+  // prepareChartDataWithDomain pads then slices off the first point
+  return Math.max(0, paddingCount + filtered.length - 1);
 }


### PR DESCRIPTION
Introduces a parseInitialRange utility to select an appropriate initial data range for DataChart based on available historical data. Updates DataChart and its consumers to use this dynamic initial range, improving chart usability and ensuring enough data points are shown by default.