### PR TITLE
fix chain id route parsing and fetch error cause

### DIFF
--- a/src/app/(app)/borrow/[chainId]/[marketId]/page.tsx
+++ b/src/app/(app)/borrow/[chainId]/[marketId]/page.tsx
@@ -8,6 +8,7 @@ import { BreakcrumbBack } from "@/common/components/ui/breakcrumb-back";
 import { Button } from "@/common/components/ui/button";
 import { Card, CardHeader } from "@/common/components/ui/card";
 import { Skeleton } from "@/common/components/ui/skeleton";
+import { parseRouteChainIdParam } from "@/common/utils/parseRouteChainId";
 import { APP_CONFIG } from "@/config";
 import type { SupportedChainId } from "@/config/types";
 import { IrmChart } from "@/modules/market/components/IrmChart";
@@ -28,10 +29,8 @@ export const metadata: Metadata = {
 
 export default async function MarketPage({ params }: { params: Promise<{ chainId: string; marketId: string }> }) {
   const { chainId: chainIdString, marketId } = await params;
-  let chainId: SupportedChainId;
-  try {
-    chainId = Number.parseInt(chainIdString) as SupportedChainId;
-  } catch {
+  const chainId = parseRouteChainIdParam(chainIdString);
+  if (chainId === undefined) {
     notFound();
   }
 

--- a/src/app/(app)/earn/[chainId]/[vaultAddress]/page.tsx
+++ b/src/app/(app)/earn/[chainId]/[vaultAddress]/page.tsx
@@ -7,8 +7,8 @@ import { BreakcrumbBack } from "@/common/components/ui/breakcrumb-back";
 import { Button } from "@/common/components/ui/button";
 import { Card, CardHeader } from "@/common/components/ui/card";
 import { Skeleton } from "@/common/components/ui/skeleton";
+import { parseRouteChainIdParam } from "@/common/utils/parseRouteChainId";
 import { APP_CONFIG } from "@/config";
-import type { SupportedChainId } from "@/config/types";
 import { Erc4626VaultProtocol } from "@/generated/gql/whisk/graphql";
 import { MorphoV1VaultPageContent } from "@/modules/vault/components/morpho-v1/MorphoV1VaultPageContent";
 import { MorphoV2VaultPageContent } from "@/modules/vault/components/morpho-v2/MorphoV2VaultPageContent";
@@ -26,11 +26,13 @@ export const metadata: Metadata = {
 
 export default async function VaultPage({ params }: { params: Promise<{ chainId: string; vaultAddress: string }> }) {
   const { chainId: chainIdString, vaultAddress: vaultAddressString } = await params;
+  const chainId = parseRouteChainIdParam(chainIdString);
+  if (chainId === undefined) {
+    notFound();
+  }
   let vaultAddress: Address;
-  let chainId: SupportedChainId;
   try {
     vaultAddress = getAddress(vaultAddressString);
-    chainId = Number.parseInt(chainIdString) as SupportedChainId;
   } catch {
     notFound();
   }

--- a/src/app/api/rpc/[chainId]/route.ts
+++ b/src/app/api/rpc/[chainId]/route.ts
@@ -1,7 +1,7 @@
 import { fetchJsonResponse } from "@/common/utils/fetch";
+import { parseRouteChainIdParam } from "@/common/utils/parseRouteChainId";
 import { tryCatch } from "@/common/utils/tryCatch";
-import { APP_CONFIG, SUPPORTED_CHAIN_IDS } from "@/config";
-import type { SupportedChainId } from "@/config/types";
+import { APP_CONFIG } from "@/config";
 
 const MAX_PAYLOAD_BYTES = 1024 * 500; // 500KB
 
@@ -24,12 +24,10 @@ type AllowedRpcMethodName = (typeof ALLOWED_RPC_METHODS)[number];
 
 export async function POST(request: Request, { params }: { params: Promise<{ chainId: string }> }) {
   const maybeChainId = (await params).chainId;
-
-  if (!maybeChainId || !SUPPORTED_CHAIN_IDS.includes(Number(maybeChainId) as SupportedChainId)) {
+  const chainId = parseRouteChainIdParam(maybeChainId);
+  if (chainId === undefined) {
     return Response.json({ error: "Invalid chain ID" }, { status: 400 });
   }
-
-  const chainId = Number(maybeChainId) as SupportedChainId;
   const rpcUrls = APP_CONFIG.chainConfig[chainId].rpcUrls;
 
   // Check Origin header is present as a simple prevention against server side abuse, but note can still be spoofed.

--- a/src/common/utils/fetch.ts
+++ b/src/common/utils/fetch.ts
@@ -58,6 +58,6 @@ export async function fetchJsonResponse<T>(url: string | URL, options?: FetchJso
       url: url.toString(),
       error: `${e}`,
     });
-    throw new Error("Fetch failed");
+    throw new Error("Fetch failed", { cause: e });
   }
 }

--- a/src/common/utils/parseRouteChainId.ts
+++ b/src/common/utils/parseRouteChainId.ts
@@ -1,0 +1,19 @@
+import { SUPPORTED_CHAIN_IDS } from "@/config";
+import type { SupportedChainId } from "@/config/types";
+
+export function parseRouteChainIdParam(chainIdString: string | undefined | null): SupportedChainId | undefined {
+  if (chainIdString == null || chainIdString === "") {
+    return undefined;
+  }
+  if (!/^\d+$/.test(chainIdString)) {
+    return undefined;
+  }
+  const id = Number(chainIdString);
+  if (!Number.isSafeInteger(id)) {
+    return undefined;
+  }
+  if (!SUPPORTED_CHAIN_IDS.includes(id as SupportedChainId)) {
+    return undefined;
+  }
+  return id as SupportedChainId;
+}

--- a/test/unit/parseRouteChainId.test.ts
+++ b/test/unit/parseRouteChainId.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "vitest";
+import { mainnet } from "viem/chains";
+import { parseRouteChainIdParam } from "@/common/utils/parseRouteChainId";
+
+describe("parseRouteChainIdParam", () => {
+  test("accepts a configured chain id as string", () => {
+    expect(parseRouteChainIdParam(String(mainnet.id))).toBe(mainnet.id);
+  });
+
+  test("rejects nan from garbage input", () => {
+    expect(parseRouteChainIdParam("not-a-number")).toBeUndefined();
+  });
+
+  test("rejects scientific notation and partial parses", () => {
+    expect(parseRouteChainIdParam("1e2")).toBeUndefined();
+    expect(parseRouteChainIdParam("42abc")).toBeUndefined();
+  });
+
+  test("rejects unsupported numeric chain", () => {
+    expect(parseRouteChainIdParam("999999999")).toBeUndefined();
+  });
+
+  test("rejects empty and nullish", () => {
+    expect(parseRouteChainIdParam("")).toBeUndefined();
+    expect(parseRouteChainIdParam(undefined)).toBeUndefined();
+    expect(parseRouteChainIdParam(null)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
hey, was reading through the app router pages and noticed the borrow and vault routes used parseInt in a try/catch, but parseInt does not throw, so garbage slugs like foobar turned into NaN and the page still rendered instead of 404. same story for numeric ids that are not in your supported list, the rpc route already checked the allowlist but the html routes did not.

pulled the logic into parseRouteChainIdParam (digit only string + safe int + SUPPORTED_CHAIN_IDS) and wired earn, borrow, and the rpc segment through it for consistency. small unit tests on the helper.

also tweaked fetchJsonResponse so rethrown errors keep the original error as cause, the generic message is the same but server logs and monitoring can walk the chain now.

cheers