### PR TITLE
docs: mark repo unmaintained and point to morpho-org fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Morpho Blueprint
 
+> [!IMPORTANT]
+> **This repository is no longer maintained.** Development has moved to [morpho-org/morpho-blueprint](https://github.com/morpho-org/morpho-blueprint), maintained by [Morpho](https://morpho.org/), which replaces Whisk with the Morpho API. Start new deployments there, and file issues and pull requests there. This repo remains available for reference only.
+
 ![Morpho Blueprint](/public/opengraph-image.png)
 
-Morpho Blueprint is an open-source [Next.js](https://nextjs.org/) white-label frontend template for the [Morpho protocol](https://morpho.xyz/) built and maintained by [Paperclip Labs](https://paperclip.xyz/). It enables anyone to deploy their own custom Morpho interface in hours instead of weeks or months.
+Morpho Blueprint is an open-source [Next.js](https://nextjs.org/) white-label frontend template for the [Morpho protocol](https://morpho.xyz/), originally built by [Paperclip Labs](https://paperclip.xyz/). It enables anyone to deploy their own custom Morpho interface in hours instead of weeks or months.
 
 ## Configuration
 
@@ -18,11 +21,9 @@ All configuration happens via files in the [config folder](src/config/), which s
     -   Check out the [`AppConfig` type definition](src/config/types.ts) for full parameter documentation
 -   [theme.css](src/config/theme.css): Customize all colors and typography to match your brand. This closely follows the standard [shadcn theming](https://ui.shadcn.com/themes). The best way to pick your theme is via the Morpho Blueprint Figma file (coming soon) which is a 1:1 match with the app's theme.
 
-All read-only data in Morpho Blueprint is powered by [Whisk](https://www.whisk.so/). Using Whisk is the fastest way to get to production, but you are welcome to replace Whisk with your own data source.
+All read-only data in this version of Morpho Blueprint is powered by [Whisk](https://www.whisk.so/). The maintained fork uses the [Morpho API](https://docs.morpho.org/) instead.
 
-[Reach out](https://paperclip.xyz/contact) if you want to use Whisk, or you're interested in a full white-glove solution including design and development. We can generally get your app to production in a few days.
-
-> If the provided customization parameters are insufficient for your use case, you can modify code outside the `/config` folder, but this will be harder to pick up additional future features and patches from this canonical template repo.
+> If the provided customization parameters are insufficient for your use case, you can modify code outside the `/config` folder, but this will be harder to pick up future features and patches from the maintained fork.
 
 ## Local Development
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "morpho-whitelabel",
+  "name": "morpho-blueprint",
   "version": "0.1.0",
   "private": true,
   "packageManager": "pnpm@10.20.0",


### PR DESCRIPTION
## Diff breakdown

> **Production code is 1 changed line** (1 file, +1 / -1): the `name` field in `package.json`. Everything else is README prose.

| Bucket | Files | Lines | Net |
| --- | --- | --- | --- |
| **Production code** | 1 | +1 / -1 | +0 |
| Docs | 1 | +6 / -5 | +1 |
| **Total** | **2** | **+7 / -6** | **+1** |

## Summary

- Adds a README notice that this repository is no longer maintained, directing new deployments, issues, and pull requests to [morpho-org/morpho-blueprint](https://github.com/morpho-org/morpho-blueprint), maintained by Morpho and backed by the Morpho API instead of Whisk.
- Corrects claims that no longer hold: "built and maintained by Paperclip Labs" becomes "originally built by", the Whisk data paragraph is scoped to this version, the Paperclip white-glove/Whisk contact line is dropped, and "this canonical template repo" now refers to the maintained fork.
- Renames the package from `morpho-whitelabel` to `morpho-blueprint` to match the project name. The package is `private: true` and no other file referenced the old name.

## Before merge

- [ ] Archive `papercliplabs/morpho-blueprint` on GitHub after this merges, not before. Archiving makes the repo read-only, so the notice has to land first.

## Verification

- `pnpm check` (Biome): passes, 285 files, no fixes applied.
- `pnpm check:types`: 74 errors, all pre-existing and environmental. The same 74 occur on the parent commit. They come from the gitignored `src/generated` directory being absent, which `pnpm codegen` produces from `WHISK_API_URL`/`WHISK_API_KEY`. This branch changes no `.ts`/`.tsx` files.
- `pnpm test`: not run. It needs those same Whisk credentials plus the mainnet/polygon RPC URLs for the anvil forks.
